### PR TITLE
Replace the use of `grok.implements()` with the `@grok.implementer()`…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Replace the use of `grok.implements()` with the `@grok.implementer()`
+  directive throughout.
 
 3.0.1 (2018-01-12)
 ------------------

--- a/src/grokcore/layout/components.py
+++ b/src/grokcore/layout/components.py
@@ -20,11 +20,11 @@ class layout(martian.Directive):
      default = ILayout
 
 
+@grok.implementer(ILayout)
 class Layout(grokcore.view.ViewSupport):
     """A layout object.
     """
     grok.baseclass()
-    grok.implements(ILayout)
 
     def __init__(self, request, context):
         self.context = context
@@ -102,11 +102,11 @@ class LayoutAware(object):
         return mapply(self.render, (), self.request)
 
 
+@grok.implementer(IPage)
 class Page(LayoutAware, grokcore.view.View):
     """A view class.
     """
     grok.baseclass()
-    grok.implements(IPage)
 
 
 class ExceptionPage(


### PR DESCRIPTION
… directive throughout.